### PR TITLE
[BW] Bump Metadata demo app to messaging android version to 2.17

### DIFF
--- a/zendesk_sdk_metadata_demo/app/build.gradle.kts
+++ b/zendesk_sdk_metadata_demo/app/build.gradle.kts
@@ -34,7 +34,7 @@ android {
 
 dependencies {
     // ZD
-    implementation("zendesk.messaging:messaging-android:2.16.0")
+    implementation("zendesk.messaging:messaging-android:2.17.0")
 
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.6.1")


### PR DESCRIPTION
Missed updating the metadata demo app to 2.17 